### PR TITLE
Fix distributed training always use GPU with highest ID in multi-GPU …

### DIFF
--- a/deep_galaxy_training.py
+++ b/deep_galaxy_training.py
@@ -102,17 +102,17 @@ class DeepGalaxyTraining(object):
 
                 # Bind a CUDA device to one MPI process (has no effect if GPUs are not used)
                 os.environ["CUDA_VISIBLE_DEVICES"] = str(hvd.local_rank())
-                
+
                 # Add callbacks
                 self.callbacks.append(hvd.callbacks.BroadcastGlobalVariablesCallback(0))
                 self.callbacks.append(hvd.callbacks.MetricAverageCallback())
                 self.callbacks.append(DataReshuffleCallback(self))
 
                 # Configure GPUs (if any)
-                gpus = tf.config.experimental.list_physical_devices('GPU')
-                for gpu in gpus:
-                    tf.config.experimental.set_memory_growth(gpu, self._gpu_memory_allow_growth)
-                    tf.config.experimental.set_visible_devices(gpu, 'GPU')
+                gpu = tf.config.experimental.list_physical_devices('GPU')[hvd.local_rank()]
+                tf.config.experimental.set_memory_growth(gpu, self._gpu_memory_allow_growth)
+                tf.config.experimental.set_visible_devices(gpu, 'GPU')
+ 
                 if self._gpu_memory_fraction is not None:
                     config = tf.compat.v1.ConfigProto()
                     config.gpu_options.per_process_gpu_memory_fraction = self._gpu_memory_fraction


### PR DESCRIPTION
Fix distributed training always use GPU with highest ID in multi-GPU nodes.

This pull request fixed the problem occur during distributed training on multi-GPU machine, i.e. when running using `mpirun` or `srun` with one task per GPU. 

The problem is a GPU with highest ID will be always selected for training, while other GPUs are idle. Moreover, multiple MPI processes try to allocate memory on a GPU, which will cause out-of-memory error.